### PR TITLE
Remove all queries from the database file in prep for adding MySQL support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/3c85f35a6a7865558b27/maintainability)](https://codeclimate.com/github/bradcypert/deckard/maintainability)
 
 ### A framework agnostic tool for running database migrations.
-###### Currently, Deckard only supports Postgres. More databases coming soon!
+###### Currently, Deckard only supports MySQL & Postgres. More databases coming soon!
 
 #### Usage
 ```bash
@@ -19,7 +19,7 @@ deckard down --host=localhost --port=5432 --user=user --password=pass --database
 - [x] Verify integrity for Postgres
 - [x] Create new migrations from Deckard
 - [x] Allow reading from Config file instead of cmd flags
-- [ ] Support for MySQL
+- [x] Support for MySQL
 
 #### Managing your databases via YAML config.
 Deckard also supports managing your databases via YAML.
@@ -40,6 +40,7 @@ prod:
     user: user
     password: pass
     database: app
+    driver: postgres
 ```
 
 Alternatively, you can provide deckard the path to the configuration value you want to use.

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -34,7 +34,7 @@ func downFunc(args []string) {
 			Queries: queries,
 		}
 
-		postgres := db.Postgres{
+		database := db.Database{
 			Dbname: cmdDatabaseName,
 			Port: cmdDatabasePort,
 			Password: cmdDatabasePassword,
@@ -42,7 +42,7 @@ func downFunc(args []string) {
 			Host: cmdDatabaseHost,
 		}
 
-		postgres.RunDown(migration)
+		database.RunDown(migration)
 	} else {
 
 	}

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -40,11 +40,12 @@ func downFunc(args []string) {
 			Password: cmdDatabasePassword,
 			User: cmdDatabaseUser,
 			Host: cmdDatabaseHost,
+			Driver: cmdDatabaseDriver,
 		}
 
 		database.RunDown(migration)
 	} else {
-
+		//	TODO: What if we have more args?
 	}
 }
 
@@ -73,42 +74,7 @@ deckard down add_users_to_other_users
 
 func init() {
 	rootCmd.AddCommand(downCmd)
-
-	downCmd.Flags().StringVarP(&cmdDatabaseConfigSelector,
-		"key",
-		"k",
-		"",
-		"The database key to use from the YAML config provided in the configFile argument.")
-
-	downCmd.Flags().StringVarP(&cmdDatabaseHost,
-		"host",
-		"t",
-		"",
-		"The host for the database you'd like to apply the down migrations to.")
-
-	downCmd.Flags().StringVarP(&cmdDatabaseName,
-		"database",
-		"d",
-		"",
-		"The database name that you'd like to apply the down migrations to")
-
-	downCmd.Flags().StringVarP(&cmdDatabaseUser,
-		"user",
-		"u",
-		"",
-		"The user you'd like to connect to the database as.")
-
-	downCmd.Flags().StringVarP(&cmdDatabasePassword,
-		"password",
-		"a",
-		"",
-		"The password for the database user that you're applying migrations as.")
-
-	downCmd.Flags().IntVarP(&cmdDatabasePort,
-		"port",
-		"p",
-		0,
-		"The port that the database you're targeting runs on.")
+	addDatabaseFlags(downCmd)
 
 	dir, _ := os.Getwd()
 	downCmd.Flags().StringVarP(&cmdInputDir,

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "github.com/spf13/viper"
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
 
 func bindVarsFromConfig() {
 	if cmdDatabaseConfigSelector != "" {
@@ -9,5 +12,50 @@ func bindVarsFromConfig() {
 		cmdDatabaseUser = viper.GetString(cmdDatabaseConfigSelector+".user")
 		cmdDatabaseHost = viper.GetString(cmdDatabaseConfigSelector+".host")
 		cmdDatabaseName = viper.GetString(cmdDatabaseConfigSelector+".database")
+		cmdDatabaseDriver = viper.GetString(cmdDatabaseConfigSelector+".driver")
 	}
+}
+
+func addDatabaseFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&cmdDatabaseConfigSelector,
+		"key",
+		"k",
+		"",
+		"The database key to use from the YAML config provided in the configFile argument.")
+
+	cmd.Flags().StringVarP(&cmdDatabaseHost,
+		"host",
+		"t",
+		"",
+		"The host for the database you'd like to apply the migrations to.")
+
+	cmd.Flags().StringVarP(&cmdDatabaseName,
+		"database",
+		"d",
+		"",
+		"The database name that you'd like to apply the migrations to")
+
+	cmd.Flags().StringVarP(&cmdDatabaseUser,
+		"user",
+		"u",
+		"",
+		"The user you'd like to connect to the database as.")
+
+	cmd.Flags().StringVarP(&cmdDatabasePassword,
+		"password",
+		"a",
+		"",
+		"The password for the database user that you're applying migrations as.")
+
+	cmd.Flags().IntVarP(&cmdDatabasePort,
+		"port",
+		"p",
+		0,
+		"The port that the database you're targeting runs on.")
+
+	cmd.Flags().StringVarP(&cmdDatabaseDriver,
+		"driver",
+		"r",
+		"",
+		"The database driver for connecting to the database. Valid options are: [mysql, postgres]")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var cmdDatabaseHost string
 var cmdDatabasePort int
 var cmdDatabaseUser string
 var cmdDatabaseName string
+var cmdDatabaseDriver string
 var cmdInputDir string
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -35,7 +35,7 @@ func upFunc(args []string) {
 			Queries: queries,
 		}
 
-		postgres := db.Postgres{
+		database := db.Database{
 			Dbname: cmdDatabaseName,
 			Port: cmdDatabasePort,
 			Password: cmdDatabasePassword,
@@ -43,7 +43,7 @@ func upFunc(args []string) {
 			Host: cmdDatabaseHost,
 		}
 
-		postgres.RunUp(migration)
+		database.RunUp(migration)
 	} else {
 
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -41,11 +41,12 @@ func upFunc(args []string) {
 			Password: cmdDatabasePassword,
 			User: cmdDatabaseUser,
 			Host: cmdDatabaseHost,
+			Driver: cmdDatabaseDriver,
 		}
 
 		database.RunUp(migration)
 	} else {
-
+		// TODO: What if we have more args?
 	}
 }
 
@@ -61,42 +62,7 @@ var upCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(upCmd)
-
-	upCmd.Flags().StringVarP(&cmdDatabaseConfigSelector,
-		"key",
-		"k",
-		"",
-		"The database key to use from the YAML config provided in the configFile argument.")
-
-	upCmd.Flags().StringVarP(&cmdDatabaseHost,
-		"host",
-		"t",
-		"",
-		"The host for the database you'd like to apply the up migrations to.")
-
-	upCmd.Flags().StringVarP(&cmdDatabaseName,
-		"database",
-		"d",
-		"",
-		"The database name that you'd like to apply the up migrations to")
-
-	upCmd.Flags().StringVarP(&cmdDatabaseUser,
-		"user",
-		"u",
-		"",
-		"The user you'd like to connect to the database as.")
-
-	upCmd.Flags().StringVarP(&cmdDatabasePassword,
-		"password",
-		"a",
-		"",
-		"The password for the database user that you're applying migrations as.")
-
-	upCmd.Flags().IntVarP(&cmdDatabasePort,
-		"port",
-		"p",
-		0,
-		"The port that the database you're targeting runs on.")
+	addDatabaseFlags(upCmd)
 
 	dir, _ := os.Getwd()
 	upCmd.Flags().StringVarP(&cmdInputDir,

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -38,7 +38,7 @@ func verifyFunc(args []string) {
 		Queries: queries,
 	}
 
-	postgres := db.Postgres{
+	database := db.Database{
 		Dbname: cmdDatabaseName,
 		Port: cmdDatabasePort,
 		Password: cmdDatabasePassword,
@@ -46,7 +46,7 @@ func verifyFunc(args []string) {
 		Host: cmdDatabaseHost,
 	}
 
-	postgres.Verify(migration)
+	database.Verify(migration)
 }
 
 // verifyCmd represents the verify command

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -44,6 +44,7 @@ func verifyFunc(args []string) {
 		Password: cmdDatabasePassword,
 		User: cmdDatabaseUser,
 		Host: cmdDatabaseHost,
+		Driver: cmdDatabaseDriver,
 	}
 
 	database.Verify(migration)
@@ -68,40 +69,5 @@ deckard verify ./migrations/1234_add_login_date_to_users.up.sql`,
 
 func init() {
 	rootCmd.AddCommand(verifyCmd)
-
-	verifyCmd.Flags().StringVarP(&cmdDatabaseConfigSelector,
-		"key",
-		"k",
-		"",
-		"The database key to use from the YAML config provided in the configFile argument.")
-
-	verifyCmd.Flags().StringVarP(&cmdDatabaseHost,
-		"host",
-		"t",
-		"",
-		"The host for the database you'd like to apply the up migrations to.")
-
-	verifyCmd.Flags().StringVarP(&cmdDatabaseName,
-		"database",
-		"d",
-		"",
-		"The database name that you'd like to apply the up migrations to")
-
-	verifyCmd.Flags().StringVarP(&cmdDatabaseUser,
-		"user",
-		"u",
-		"",
-		"The user you'd like to connect to the database as.")
-
-	verifyCmd.Flags().StringVarP(&cmdDatabasePassword,
-		"password",
-		"a",
-		"",
-		"The password for the database user that you're applying migrations as.")
-
-	verifyCmd.Flags().IntVarP(&cmdDatabasePort,
-		"port",
-		"p",
-		0,
-		"The port that the database you're targeting runs on.")
+	addDatabaseFlags(verifyCmd)
 }

--- a/db/database.go
+++ b/db/database.go
@@ -6,10 +6,23 @@ import (
 	"encoding/hex"
 	"fmt"
 	_ "github.com/lib/pq" // import for side effects
+	_ "github.com/go-sql-driver/mysql"
 	"io"
 	"log"
 	"strings"
 )
+
+const ValidationError = `Warning: Deckard cannot verify the migration.
+Please ensure that the migration has not been changed locally since it was last ran.
+If the migration has been changed, you may want to run deckard down and deckard up again.
+Consider backing up your data before running deckard down.`
+
+const FailedToWriteMetadata = "Failed to write migration metadata.\n"
+const FailedToDeleteMetadata = "Failed to delete migration metadata.\n"
+const FailedToExecuteMigration = "Failed to execute migration!"
+const NoMigrationsRan = "No Migrations Were Ran!"
+const FailedToEnsureMetadataTable = "Failed to ensure that the metadata table used by Deckard exists. I tried to execute the following query and failed:"
+const FailedToHash = "Failed to Hash:"
 
 // Database a structure for defining a database connection string.
 type Database struct {
@@ -18,87 +31,80 @@ type Database struct {
 	User string
 	Password string
 	Dbname string
+	Driver string
 }
 
 // RunUp Runs an up migration against a given database.
 func (d Database) RunUp(migration Migration) {
-	const driver string = "postgres" // TODO: Change me
-	db := d.connect(driver)
+	db := d.connect(d.Driver)
 	defer db.Close()
 	ranSomething := false
 	for _, query := range migration.Queries {
-		if hasDbAlreadyRan(driver, db, query) {
+		if hasDbAlreadyRan(d.Driver, db, query) {
 			continue
 		}
 		println(query.Value)
 		_, err := db.Exec(query.Value)
 		ranSomething = true
 		if err == nil {
-			_, err = storeMigrationMetadata(driver, db, query)
+			_, err = storeMigrationMetadata(d.Driver, db, query)
 			if err != nil {
-				log.Fatal("Failed to write migration metadata.\n", err)
+				log.Fatal(FailedToWriteMetadata, err)
 			}
 		} else {
-			log.Fatal("Failed to execute migration!", err)
+			log.Fatal(FailedToExecuteMigration, err)
 		}
 	}
 
 	if !ranSomething {
-		fmt.Println("No migrations were ran!")
+		fmt.Println(NoMigrationsRan)
 	}
 }
 
 // RunDown Runs a down migration against a given database.
-func (p Database) RunDown(migration Migration) {
-	const driver string = "postgres"
-	db := p.connect(driver)
+func (d Database) RunDown(migration Migration) {
+	db := d.connect(d.Driver)
 	defer db.Close()
 	ranSomething := false
 	for _, query := range migration.Queries {
-		if !canRunDownMigration(driver, db, query) {
+		if !canRunDownMigration(d.Driver, db, query) {
 			continue
 		}
 		println(query.Value)
 		_, err := db.Exec(query.Value)
 		ranSomething = true
 		if err == nil {
-			_, err = deleteMigrationMetadata(driver, db, query)
+			_, err = deleteMigrationMetadata(d.Driver, db, query)
 			if err != nil {
-				log.Fatal("Failed to delete migration metadata.")
+				log.Fatal(FailedToDeleteMetadata)
 			}
 		} else {
-			log.Fatal("Failed to execute migration!", err)
+			log.Fatal(FailedToExecuteMigration, err)
 		}
 	}
 
 	if !ranSomething {
-		fmt.Println("No migrations were ran!")
+		fmt.Println(NoMigrationsRan)
 	}
 }
 
 // Verify verifies that a given migration has been ran against a given database.
 func (d Database) Verify(migration Migration) {
-	const driver string = "postgres"
-	db := d.connect(driver)
+	db := d.connect(d.Driver)
 	defer db.Close()
 	for _, query := range migration.Queries {
 		println("Verifying:", query.Value)
 
-		if hasDbAlreadyRan(driver, db, query) {
+		if hasDbAlreadyRan(d.Driver, db, query) {
 			fmt.Println(`Validation Successful! It looks like you've already ran`, query.Value, `on this database.`)
 		} else {
-			fmt.Println(`Warning: Deckard cannot verify the migration.
-Please ensure that the migration has not been changed locally since it was last ran.
-If the migration has been changed, you may want to run deckard down and deckard up again.
-Consider backing up your data before running deckard down.`)
+			fmt.Println(ValidationError)
 		}
 	}
 }
 
 func (d Database) connect(driver string) *sql.DB {
-	connectionInfo := fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=disable",
-		d.Host, d.Port, d.User, d.Password, d.Dbname)
+	connectionInfo := getConnectionInfoForDatabase(d)
 
 	db, err := sql.Open(driver, connectionInfo)
 	if err != nil {
@@ -120,7 +126,7 @@ func ensureDeckardTableExists(driver string, db sql.DB) (sql.Result, error) {
 
 	result, err := db.Exec(sqlStatement)
 	if err != nil {
-		log.Fatal("Failed to ensure that the metadata table used by Deckard exists. I tried to execute the following query and failed:", sqlStatement, err)
+		log.Fatal(FailedToEnsureMetadataTable, sqlStatement, err)
 	}
 
 	return result, err
@@ -130,7 +136,7 @@ func createHash(s string) string {
 	hash := md5.New()
 	_, err := io.WriteString(hash, s)
 	if err != nil {
-		log.Fatal("Failed to hash:", s, "\nTerminating...")
+		log.Fatal(FailedToHash, s, "\nTerminating...")
 	}
 	return hex.EncodeToString(hash.Sum(nil)[:])
 }
@@ -151,7 +157,7 @@ func canRunDownMigration(driver string, db *sql.DB, query Query) bool {
 	var name string
 	var hash string
 	var id int
-	sqlStatement := getSelectIdNameHashFromMetadataWhereNameQueryForDriver(driver)
+	sqlStatement := getSelectIDNameHashFromMetadataWhereNameQueryForDriver(driver)
 	upName := strings.ReplaceAll(query.Name, ".down.sql", ".up.sql")
 	row := db.QueryRow(sqlStatement, upName)
 	switch err := row.Scan(&id, &name, &hash); err {
@@ -168,7 +174,7 @@ func hasDbAlreadyRan(driver string, db *sql.DB, query Query) bool {
 	var name string
 	var hash string
 	var id int
-	sqlStatement := getSelectIdNameHashFromMetadataWhereHashQueryForDriver(driver)
+	sqlStatement := getSelectIDNameHashFromMetadataWhereHashQueryForDriver(driver)
 	row := db.QueryRow(sqlStatement, createHash(query.Value))
 	switch err := row.Scan(&id, &name, &hash); err {
 	case sql.ErrNoRows:

--- a/db/database.go
+++ b/db/database.go
@@ -1,0 +1,177 @@
+package db
+
+import (
+	"crypto/md5"
+	"database/sql"
+	"encoding/hex"
+	"fmt"
+	_ "github.com/lib/pq"
+	"io"
+	"log"
+	"strings"
+)
+
+type Database struct {
+	Host string
+	Port int
+	User string
+	Password string
+	Dbname string
+}
+
+func (d Database) connect(driver string) *sql.DB {
+	connectionInfo := fmt.Sprintf("host=%s port=%d user=%s "+
+		"password=%s dbname=%s sslmode=disable",
+		d.Host, d.Port, d.User, d.Password, d.Dbname)
+
+	db, err := sql.Open(driver, connectionInfo)
+	if err != nil {
+		panic(err)
+	}
+
+	err = db.Ping()
+	if err != nil {
+		panic(err)
+	}
+
+	ensureDeckardTableExists(driver, *db)
+
+	return db
+}
+
+func ensureDeckardTableExists(driver string, db sql.DB) (sql.Result, error) {
+	sqlStatement := getCreateMetadataQueryForDriver(driver)
+
+	result, err := db.Exec(sqlStatement)
+	if err != nil {
+		log.Fatal("Failed to ensure that the metadata table used by Deckard exists. I tried to execute the following query and failed:", sqlStatement, err)
+	}
+
+	return result, err
+}
+
+func createHash(s string) string {
+	hash := md5.New()
+	_, err := io.WriteString(hash, s)
+	if err != nil {
+		log.Fatal("Failed to hash:", s, "\nTerminating...")
+	}
+	return hex.EncodeToString(hash.Sum(nil)[:])
+}
+
+func storeMigrationMetadata(driver string, db *sql.DB, query Query) (sql.Result, error) {
+	sqlStatement := getInsertIntoMetadataQueryForDriver(driver)
+	hash := createHash(query.Value)
+	return db.Exec(sqlStatement, query.Name, hash)
+}
+
+func (d Database) RunUp(migration Migration) {
+	const driver string = "postgres" // TODO: Change me
+	db := d.connect(driver)
+	defer db.Close()
+	ranSomething := false
+	for _, query := range migration.Queries {
+		if hasDbAlreadyRan(driver, db, query) {
+			continue
+		}
+		println(query.Value)
+		_, err := db.Exec(query.Value)
+		ranSomething = true
+		if err == nil {
+			_, err = storeMigrationMetadata(driver, db, query)
+			if err != nil {
+				log.Fatal("Failed to write migration metadata.\n", err)
+			}
+		} else {
+			log.Fatal("Failed to execute migration!", err)
+		}
+	}
+
+	if !ranSomething {
+		fmt.Println("No migrations were ran!")
+	}
+}
+
+func deleteMigrationMetadata(driver string, db *sql.DB, query Query) (sql.Result, error) {
+	sqlStatement := getDeleteFromMetadataQueryForDriver(driver)
+	upName := strings.ReplaceAll(query.Name, ".down.sql", ".up.sql")
+	return db.Exec(sqlStatement, upName)
+}
+
+func (p Database) RunDown(migration Migration) {
+	const driver string = "postgres"
+	db := p.connect(driver)
+	defer db.Close()
+	ranSomething := false
+	for _, query := range migration.Queries {
+		if !canRunDownMigration(driver, db, query) {
+			continue
+		}
+		println(query.Value)
+		_, err := db.Exec(query.Value)
+		ranSomething = true
+		if err == nil {
+			_, err = deleteMigrationMetadata(driver, db, query)
+			if err != nil {
+				log.Fatal("Failed to delete migration metadata.")
+			}
+		} else {
+			log.Fatal("Failed to execute migration!", err)
+		}
+	}
+
+	if !ranSomething {
+		fmt.Println("No migrations were ran!")
+	}
+}
+
+func canRunDownMigration(driver string, db *sql.DB, query Query) bool {
+	var name string
+	var hash string
+	var id int
+	sqlStatement := getSelectIdNameHashFromMetadataWhereNameQueryForDriver(driver)
+	upName := strings.ReplaceAll(query.Name, ".down.sql", ".up.sql")
+	row := db.QueryRow(sqlStatement, upName)
+	switch err := row.Scan(&id, &name, &hash); err {
+	case sql.ErrNoRows:
+		return false
+	case nil:
+		return true
+	default:
+		return false
+	}
+}
+
+func hasDbAlreadyRan(driver string, db *sql.DB, query Query) bool {
+	var name string
+	var hash string
+	var id int
+	sqlStatement := getSelectIdNameHashFromMetadataWhereHashQueryForDriver(driver)
+	row := db.QueryRow(sqlStatement, createHash(query.Value))
+	switch err := row.Scan(&id, &name, &hash); err {
+	case sql.ErrNoRows:
+		return false
+	case nil:
+		return true
+	default:
+		return false
+	}
+}
+
+func (d Database) Verify(migration Migration) {
+	const driver string = "postgres"
+	db := d.connect(driver)
+	defer db.Close()
+	for _, query := range migration.Queries {
+		println("Verifying:", query.Value)
+
+		if hasDbAlreadyRan(driver, db, query) {
+			fmt.Println(`Validation Successful! It looks like you've already ran`, query.Value, `on this database.`)
+		} else {
+			fmt.Println(`Warning: Deckard cannot verify the migration.
+Please ensure that the migration has not been changed locally since it was last ran.
+If the migration has been changed, you may want to run deckard down and deckard up again.
+Consider backing up your data before running deckard down.`)
+		}
+	}
+}

--- a/db/database.go
+++ b/db/database.go
@@ -12,17 +12,17 @@ import (
 	"strings"
 )
 
-const ValidationError = `Warning: Deckard cannot verify the migration.
+const validationError = `Warning: Deckard cannot verify the migration.
 Please ensure that the migration has not been changed locally since it was last ran.
 If the migration has been changed, you may want to run deckard down and deckard up again.
 Consider backing up your data before running deckard down.`
 
-const FailedToWriteMetadata = "Failed to write migration metadata.\n"
-const FailedToDeleteMetadata = "Failed to delete migration metadata.\n"
-const FailedToExecuteMigration = "Failed to execute migration!"
-const NoMigrationsRan = "No Migrations Were Ran!"
-const FailedToEnsureMetadataTable = "Failed to ensure that the metadata table used by Deckard exists. I tried to execute the following query and failed:"
-const FailedToHash = "Failed to Hash:"
+const failedToWriteMetadata = "Failed to write migration metadata.\n"
+const failedToDeleteMetadata = "Failed to delete migration metadata.\n"
+const failedToExecuteMigration = "Failed to execute migration!"
+const noMigrationsRan = "No Migrations Were Ran!"
+const failedToEnsureMetadataTable = "Failed to ensure that the metadata table used by Deckard exists. I tried to execute the following query and failed:"
+const failedToHash = "Failed to Hash:"
 
 // Database a structure for defining a database connection string.
 type Database struct {
@@ -49,15 +49,15 @@ func (d Database) RunUp(migration Migration) {
 		if err == nil {
 			_, err = storeMigrationMetadata(d.Driver, db, query)
 			if err != nil {
-				log.Fatal(FailedToWriteMetadata, err)
+				log.Fatal(failedToWriteMetadata, err)
 			}
 		} else {
-			log.Fatal(FailedToExecuteMigration, err)
+			log.Fatal(failedToExecuteMigration, err)
 		}
 	}
 
 	if !ranSomething {
-		fmt.Println(NoMigrationsRan)
+		fmt.Println(noMigrationsRan)
 	}
 }
 
@@ -76,15 +76,15 @@ func (d Database) RunDown(migration Migration) {
 		if err == nil {
 			_, err = deleteMigrationMetadata(d.Driver, db, query)
 			if err != nil {
-				log.Fatal(FailedToDeleteMetadata)
+				log.Fatal(failedToDeleteMetadata)
 			}
 		} else {
-			log.Fatal(FailedToExecuteMigration, err)
+			log.Fatal(failedToExecuteMigration, err)
 		}
 	}
 
 	if !ranSomething {
-		fmt.Println(NoMigrationsRan)
+		fmt.Println(noMigrationsRan)
 	}
 }
 
@@ -98,7 +98,7 @@ func (d Database) Verify(migration Migration) {
 		if hasDbAlreadyRan(d.Driver, db, query) {
 			fmt.Println(`Validation Successful! It looks like you've already ran`, query.Value, `on this database.`)
 		} else {
-			fmt.Println(ValidationError)
+			fmt.Println(validationError)
 		}
 	}
 }
@@ -126,7 +126,7 @@ func ensureDeckardTableExists(driver string, db sql.DB) (sql.Result, error) {
 
 	result, err := db.Exec(sqlStatement)
 	if err != nil {
-		log.Fatal(FailedToEnsureMetadataTable, sqlStatement, err)
+		log.Fatal(failedToEnsureMetadataTable, sqlStatement, err)
 	}
 
 	return result, err
@@ -136,7 +136,7 @@ func createHash(s string) string {
 	hash := md5.New()
 	_, err := io.WriteString(hash, s)
 	if err != nil {
-		log.Fatal(FailedToHash, s, "\nTerminating...")
+		log.Fatal(failedToHash, s, "\nTerminating...")
 	}
 	return hex.EncodeToString(hash.Sum(nil)[:])
 }

--- a/db/db_flavors.go
+++ b/db/db_flavors.go
@@ -1,21 +1,58 @@
 package db
 
+import "fmt"
+
 func getCreateMetadataQueryForDriver(driver string) string {
-	return postgresMetadataTableExists
+	switch driver {
+	case "mysql":
+		return mySQLMetadataTableExists
+	default: // postgres
+		return  postgresMetadataTableExists
+	}
 }
 
 func getInsertIntoMetadataQueryForDriver(driver string) string {
-	return postgresInsertIntoMetadataTable
+	switch driver {
+	case "mysql":
+		return mySQLInsertIntoMetadataTable
+	default: // postgres
+		return  postgresInsertIntoMetadataTable
+	}
 }
 
 func getDeleteFromMetadataQueryForDriver(driver string) string {
-	return postgresDeleteFromMetadataTable
+	switch driver {
+	case "mysql":
+		return mySQLDeleteFromMetadataTable
+	default: // postgres
+		return  postgresDeleteFromMetadataTable
+	}
 }
 
-func getSelectIdNameHashFromMetadataWhereNameQueryForDriver(driver string) string {
-	return postgresSelectIdNameHashFromMetadataTableWhereName
+func getSelectIDNameHashFromMetadataWhereNameQueryForDriver(driver string) string {
+	switch driver {
+	case "mysql":
+		return mySQLSelectIDNameHashFromMetadataTableWhereName
+	default: // postgres
+		return  postgresSelectIDNameHashFromMetadataTableWhereName
+	}
 }
 
-func getSelectIdNameHashFromMetadataWhereHashQueryForDriver(driver string) string {
-	return postgresSelectIdNameHashFromMetadataTableWhereHash
+func getSelectIDNameHashFromMetadataWhereHashQueryForDriver(driver string) string {
+	switch driver {
+	case "mysql":
+		return mySQLSelectIDNameHashFromMetadataTableWhereHash
+	default: // postgres
+		return  postgresSelectIDNameHashFromMetadataTableWhereHash
+	}
+}
+
+func getConnectionInfoForDatabase(d Database) string {
+	switch d.Driver {
+	case "mysql":
+		return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", d.User, d.Password, d.Host, d.Port, d.Dbname)
+	default: // postgres
+		return  fmt.Sprintf("host=%s port=%d user=%s "+
+			"password=%s dbname=%s sslmode=disable",d.Host, d.Port, d.User, d.Password, d.Dbname)
+	}
 }

--- a/db/db_flavors.go
+++ b/db/db_flavors.go
@@ -1,0 +1,21 @@
+package db
+
+func getCreateMetadataQueryForDriver(driver string) string {
+	return postgresMetadataTableExists
+}
+
+func getInsertIntoMetadataQueryForDriver(driver string) string {
+	return postgresInsertIntoMetadataTable
+}
+
+func getDeleteFromMetadataQueryForDriver(driver string) string {
+	return postgresDeleteFromMetadataTable
+}
+
+func getSelectIdNameHashFromMetadataWhereNameQueryForDriver(driver string) string {
+	return postgresSelectIdNameHashFromMetadataTableWhereName
+}
+
+func getSelectIdNameHashFromMetadataWhereHashQueryForDriver(driver string) string {
+	return postgresSelectIdNameHashFromMetadataTableWhereHash
+}

--- a/db/mysql.go
+++ b/db/mysql.go
@@ -1,0 +1,21 @@
+package db
+
+const mySQLMetadataTableExists string = `
+CREATE TABLE IF NOT EXISTS deckard_horadric_cube (
+  id int NOT NULL AUTO_INCREMENT,
+  name TEXT NOT NULL,
+  hash TEXT NOT NULL,
+  primary key (id)
+)`
+
+const mySQLInsertIntoMetadataTable string =
+	`INSERT INTO deckard_horadric_cube (name, hash) VALUES (?, ?)`
+
+const mySQLDeleteFromMetadataTable string =
+	`DELETE FROM deckard_horadric_cube WHERE name = ?`
+
+const mySQLSelectIDNameHashFromMetadataTableWhereName string =
+	`SELECT id, name, hash FROM deckard_horadric_cube WHERE name = ?`
+
+const mySQLSelectIDNameHashFromMetadataTableWhereHash string =
+	`SELECT id, name, hash FROM deckard_horadric_cube WHERE hash=?;`

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -1,180 +1,24 @@
 package db
 
 import (
-	"crypto/md5"
-	"database/sql"
-	"encoding/hex"
-	"fmt"
 	_ "github.com/lib/pq"
-	"io"
-	"log"
-	"strings"
 )
 
-type Postgres struct {
-	Host string
-	Port int
-	User string
-	Password string
-	Dbname string
-}
-
-func (p Postgres) connect() *sql.DB {
-	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s "+
-		"password=%s dbname=%s sslmode=disable",
-		p.Host, p.Port, p.User, p.Password, p.Dbname)
-
-	db, err := sql.Open("postgres", psqlInfo)
-	if err != nil {
-		panic(err)
-	}
-
-	err = db.Ping()
-	if err != nil {
-		panic(err)
-	}
-
-	ensureDeckardTableExists(*db)
-
-	return db
-}
-
-func ensureDeckardTableExists(db sql.DB) (sql.Result, error) {
-	sqlStatement := `
+const postgresMetadataTableExists string = `
 CREATE TABLE IF NOT EXISTS deckard_horadric_cube (
   id SERIAL,
   name TEXT NOT NULL,
   hash TEXT NOT NULL
 )`
 
-	result, err := db.Exec(sqlStatement)
+const postgresInsertIntoMetadataTable string =
+	`INSERT INTO deckard_horadric_cube (name, hash) VALUES ($1, $2)`
 
-	if err != nil {
-		log.Fatal("Failed to ensure that the metadata table used by Deckard exists. I tried to execute the following query and failed:", sqlStatement, err)
-	}
+const postgresDeleteFromMetadataTable string =
+	`DELETE FROM deckard_horadric_cube WHERE name = $1`
 
-	return result, err
-}
+const postgresSelectIdNameHashFromMetadataTableWhereName string =
+	`SELECT id, name, hash FROM deckard_horadric_cube WHERE name = $1`
 
-func createHash(s string) string {
-	hash := md5.New()
-	_, err := io.WriteString(hash, s)
-	if err != nil {
-		log.Fatal("Failed to hash:", s, "\nTerminating...")
-	}
-	return hex.EncodeToString(hash.Sum(nil)[:])
-}
-
-func storeMigrationMetadata(db *sql.DB, query Query) (sql.Result, error) {
-	sqlStatement := `INSERT INTO deckard_horadric_cube (name, hash) VALUES ($1, $2)`
-	hash := createHash(query.Value)
-	return db.Exec(sqlStatement, query.Name, hash)
-}
-
-func (p Postgres) RunUp(migration Migration) {
-	db := p.connect()
-	defer db.Close()
-	ranSomething := false
-	for _, query := range migration.Queries {
-		if hasDbAlreadyRan(db, query) {
-			continue
-		}
-		println(query.Value)
-		_, err := db.Exec(query.Value)
-		ranSomething = true
-		if err == nil {
-			_, err = storeMigrationMetadata(db, query)
-			if err != nil {
-				log.Fatal("Failed to write migration metadata.\n", err)
-			}
-		} else {
-			log.Fatal("Failed to execute migration!", err)
-		}
-	}
-
-	if !ranSomething {
-		fmt.Println("No migrations were ran!")
-	}
-}
-
-func deleteMigrationMetadata(db *sql.DB, query Query) (sql.Result, error) {
-	sqlStatement := `DELETE FROM deckard_horadric_cube WHERE name = $1`
-	upName := strings.ReplaceAll(query.Name, ".down.sql", ".up.sql")
-	return db.Exec(sqlStatement, upName)
-}
-
-func (p Postgres) RunDown(migration Migration) {
-	db := p.connect()
-	defer db.Close()
-	ranSomething := false
-	for _, query := range migration.Queries {
-		if !canRunDownMigration(db, query) {
-			continue
-		}
-		println(query.Value)
-		_, err := db.Exec(query.Value)
-		ranSomething = true
-		if err == nil {
-			_, err = deleteMigrationMetadata(db, query)
-			if err != nil {
-				log.Fatal("Failed to delete migration metadata.")
-			}
-		} else {
-			log.Fatal("Failed to execute migration!", err)
-		}
-	}
-
-	if !ranSomething {
-		fmt.Println("No migrations were ran!")
-	}
-}
-
-func canRunDownMigration(db *sql.DB, query Query) bool {
-	var name string
-	var hash string
-	var id int
-	sqlStatement := `SELECT id, name, hash FROM deckard_horadric_cube WHERE name = $1`
-	upName := strings.ReplaceAll(query.Name, ".down.sql", ".up.sql")
-	row := db.QueryRow(sqlStatement, upName)
-	switch err := row.Scan(&id, &name, &hash); err {
-	case sql.ErrNoRows:
-		return false
-	case nil:
-		return true
-	default:
-		return false
-	}
-}
-
-func hasDbAlreadyRan(db *sql.DB, query Query) bool {
-	var name string
-	var hash string
-	var id int
-	sqlStatement := `SELECT id, name, hash FROM deckard_horadric_cube WHERE hash=$1;`
-	row := db.QueryRow(sqlStatement, createHash(query.Value))
-	switch err := row.Scan(&id, &name, &hash); err {
-	case sql.ErrNoRows:
-		return false
-	case nil:
-		return true
-	default:
-		return false
-	}
-}
-
-func (p Postgres) Verify(migration Migration) {
-	db := p.connect()
-	defer db.Close()
-	for _, query := range migration.Queries {
-		println("Verifying:", query.Value)
-
-		if hasDbAlreadyRan(db, query) {
-			fmt.Println(`Validation Successful! It looks like you've already ran`, query.Value, `on this database.`)
-		} else {
-			fmt.Println(`Warning: Deckard cannot verify the migration.
-Please ensure that the migration has not been changed locally since it was last ran.
-If the migration has been changed, you may want to run deckard down and deckard up again.
-Consider backing up your data before running deckard down.`)
-		}
-	}
-}
+const postgresSelectIdNameHashFromMetadataTableWhereHash string =
+	`SELECT id, name, hash FROM deckard_horadric_cube WHERE hash=$1;`

--- a/db/postgres.go
+++ b/db/postgres.go
@@ -1,9 +1,5 @@
 package db
 
-import (
-	_ "github.com/lib/pq"
-)
-
 const postgresMetadataTableExists string = `
 CREATE TABLE IF NOT EXISTS deckard_horadric_cube (
   id SERIAL,
@@ -17,8 +13,8 @@ const postgresInsertIntoMetadataTable string =
 const postgresDeleteFromMetadataTable string =
 	`DELETE FROM deckard_horadric_cube WHERE name = $1`
 
-const postgresSelectIdNameHashFromMetadataTableWhereName string =
+const postgresSelectIDNameHashFromMetadataTableWhereName string =
 	`SELECT id, name, hash FROM deckard_horadric_cube WHERE name = $1`
 
-const postgresSelectIdNameHashFromMetadataTableWhereHash string =
+const postgresSelectIDNameHashFromMetadataTableWhereHash string =
 	`SELECT id, name, hash FROM deckard_horadric_cube WHERE hash=$1;`

--- a/example.deckard.yml
+++ b/example.deckard.yml
@@ -4,6 +4,7 @@ local:
   user: test
   password: test
   database: test_db
+  driver: postgres
 
 prod:
   host: localhost
@@ -11,3 +12,12 @@ prod:
   user: test
   password: test
   database: test_prod_db
+  driver: postgres
+
+local_mysql:
+  host: localhost
+  port: 3306
+  user: root
+  password: test
+  database: test_db
+  driver: mysql


### PR DESCRIPTION
This is a first pass at a minor refactoring of the db layer so that we can support multiple drivers. I'd love to infer the database off of the port and assume no one would ever run MySQL on port 5432, but I think I'll also need to update the config so that you can specify the driver in the config or via a cmd line flag.