### PR TITLE
Require SSL on postgres. Probably want to make this configurable.

### DIFF
--- a/db/db_flavors.go
+++ b/db/db_flavors.go
@@ -53,6 +53,6 @@ func getConnectionInfoForDatabase(d Database) string {
 		return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s", d.User, d.Password, d.Host, d.Port, d.Dbname)
 	default: // postgres
 		return fmt.Sprintf("host=%s port=%d user=%s "+
-			"password=%s dbname=%s sslmode=disable", d.Host, d.Port, d.User, d.Password, d.Dbname)
+			"password=%s dbname=%s sslmode=require", d.Host, d.Port, d.User, d.Password, d.Dbname)
 	}
 }


### PR DESCRIPTION
I'm not sure if this is a good call overall or not.

I understand that some clients will require Postgres to validate SSL, and that's fine, but it'd probably be best to make it configurable, especially since not all servers will require SSL.

Regardless, this is the shortest workaround to running migrations against HerokuPG.

It should probably be configurable, however.